### PR TITLE
closes #6: add support for custom named attributes via options.attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,31 @@ return (
 );
 ```
 
-Make sure the plugins are part of your babel config, and build away - that's it. ```data-test-id```'s will be stripped.
+### Define custom attribute name(s)
+
+By default attributes with name ```data-test-id``` will be stripped. You can also define custom attribute names via plugin options in your babel config:
+
+```javascript
+plugins: [
+    'babel-plugin-jsx-remove-data-test-id',
+    {
+      attributes: 'selenium-id'
+    }
+]
+```
+
+Or if you need to strip off multiple attributes, you can define an attributes array as follows:
+```javascript
+plugins: [
+    'babel-plugin-jsx-remove-data-test-id',
+    {
+      attributes: [
+        'data-test-id',
+        'selenium-id',
+        'another-attr-to-be-stripped'
+      ]
+    }
+]
+```
+
+Make sure the plugins are part of your babel config, and build away - that's it. ```data-test-id```'s (respectively your custom named attributes) will be stripped.

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,25 @@
+const getAttributeIdentifiers = options => {
+  if(!options || typeof(options.attributes) === 'undefined') return ['data-test-id'];
+  
+  if(Array.isArray(options.attributes)) {
+    if(options.attributes.length === 0) {
+      throw new Error('option attributes must be an array with at least one element');
+    }
+    
+    if (options.attributes.length !==  options.attributes.filter(attr => attr && typeof(attr) === 'string').length) {
+      throw new Error('all items in the option attributes must be non empty strings');
+    }
+    
+    return options.attributes;
+  }
+  
+  if(!options.attributes || typeof(options.attributes) !== 'string') {
+    throw new Error('option attributes must be a non empty string or an array with non empty strings');
+  }
+  
+  return [options.attributes];
+}
+
 const RemoveDataTestIds = ({ types: t }) => {
   const visitor = {
     JSXOpeningElement: (path, state) => {
@@ -5,7 +27,7 @@ const RemoveDataTestIds = ({ types: t }) => {
         return;
       }
 
-      const attributeIdentifiers = ['data-test-id'];
+      const attributeIdentifiers = getAttributeIdentifiers(state.opts);
 
       const validTestIdAttributes = attr => {
         const isIdent = attributeIdentifiers.find(

--- a/tests/remove-data-test-id.spec.js
+++ b/tests/remove-data-test-id.spec.js
@@ -60,4 +60,75 @@ describe('jsx-remove-data-test-id', () => {
     const expected = transform(expectedCode, configWithoutPlugin).code;
     expect(uglify(actual)).to.equal(uglify(expected));
   });
+
+  describe('with invalid options.attributes', () => {
+    it('throws error when attributes is empty string', () => {
+      const configWithErroneousAttributesOption = {
+        plugins: [
+          ['./src', {attributes: ''}],
+          ['transform-react-jsx', { pragma: 'j' }],
+          ['transform-es2015-arrow-functions', {}]
+        ]
+      };
+      const code = '<p selenium-id={false}></p>';
+      const expectedCode = '<p></p>';
+      const action = () => transform(code, configWithErroneousAttributesOption);
+      expect(action).to.throw();
+    });
+
+    it('throws error when attributes is empty array', () => {
+      const configWithErroneousAttributesOption = {
+        plugins: [
+          ['./src', {attributes: []}],
+          ['transform-react-jsx', { pragma: 'j' }],
+          ['transform-es2015-arrow-functions', {}]
+        ]
+      };
+      const code = '<p selenium-id={false}></p>';
+      const expectedCode = '<p></p>';
+      const action = () => transform(code, configWithErroneousAttributesOption);
+      expect(action).to.throw();
+    });
+  })
+
+  describe('with valid options.attributes', () => {
+    const configWithValidAttributesOption = {
+      plugins: [
+        ['./src', { attributes: [ 'selenium-id', 'useless-attr' ] }],
+        ['transform-react-jsx', { pragma: 'j' }],
+        ['transform-es2015-arrow-functions', {}]
+      ]
+    };
+
+    it('does not remove attributes that match options.attributes in part only', () => {
+      const code = '<p selenium-id-not="not-test-id" no-useless-attr="useless">hi, finally it is cake time</p>';
+      const actual = transform(code, configWithValidAttributesOption).code;
+      const expected = transform(code, configWithoutPlugin).code;
+      expect(uglify(actual)).to.equal(uglify(expected));
+    });
+
+    it('removes options.attributes', () => {
+      const code = '<p selenium-id="test-id" useless-attr="useless"></p>';
+      const expectedCode = '<p></p>';
+      const actual = transform(code, configWithValidAttributesOption).code;
+      const expected = transform(expectedCode, configWithoutPlugin).code;
+      expect(uglify(actual)).to.equal(uglify(expected));
+    });
+
+    it('removes options.attributes funcs', () => {
+      const code = '<p selenium-id={() => {}} useless-attr={() => {}}></p>';
+      const expectedCode = '<p></p>';
+      const actual = transform(code, configWithValidAttributesOption).code;
+      const expected = transform(expectedCode, configWithoutPlugin).code;
+      expect(uglify(actual)).to.equal(uglify(expected));
+    });
+
+    it('removes options.attributes bools', () => {
+      const code = '<p selenium-id={false} useless-attr={true}></p>';
+      const expectedCode = '<p></p>';
+      const actual = transform(code, configWithValidAttributesOption).code;
+      const expected = transform(expectedCode, configWithoutPlugin).code;
+      expect(uglify(actual)).to.equal(uglify(expected));
+    });
+  })
 });


### PR DESCRIPTION
Adds support for custom named attributes, that shall be stripped by the plugin.

Custom attribute string:
```javascript
plugins: [
    'babel-plugin-jsx-remove-data-test-id',
    { attributes: 'selenium-id' }
]
```

Custom attribute string array:
```javascript
plugins: [
    'babel-plugin-jsx-remove-data-test-id',
    { attributes: ['selenium-id', 'data-test-id', 'another-attr-to-be-stripped'] }
]
```

Maybe you find it somehow useful.