### PR TITLE
Add support for data-testid used by default in react-testing-library

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 const getAttributeIdentifiers = options => {
-  if(!options || typeof(options.attributes) === 'undefined') return ['data-test-id'];
+  if(!options || typeof(options.attributes) === 'undefined') return ['data-test-id', 'data-testid'];
   
   if(Array.isArray(options.attributes)) {
     if(options.attributes.length === 0) {


### PR DESCRIPTION
This changes are convenient for users of react-testing-library, so they won't have to configure it.