### PR TITLE
Use babel7 and make it a peer dep

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-    "presets": ["es2015"],
-    "plugins": ["transform-react-jsx"]
+    "presets": [["@babel/preset-env", { "targets": { "node": 6 } }]],
+    "plugins": ["@babel/plugin-transform-react-jsx"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+lib
 .DS_Store
 .idea
 .vscode

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ return (
 );
 ```
 
+### Peer dependency warnings
+
+This plugin specifies Babel 7 as its peer dependency - while it also works with Babel 6 you might want to install `@babel/core@6.0.0-bridge.1` to get rid of unmet peer dependency warnings.
+
 ### Define custom attribute name(s)
 
 By default attributes with name `data-test-id` or `data-testid` (as used in [react-testing-library](https://testing-library.com/react)) will be stripped. You can also define custom attribute names via plugin options in your babel config:

--- a/package.json
+++ b/package.json
@@ -21,19 +21,25 @@
   "repository": "git://github.com/coderas/babel-plugin-jsx-remove-data-test-id.git",
   "scripts": {
     "build": "babel src --out-dir lib",
-    "prepublish": "babel src --out-dir lib",
-    "test": "mocha \"**/*.spec.js\" --compilers js:babel-core/register --reporter spec"
+    "prepare": "npm test && npm run build",
+    "test": "mocha \"**/*.spec.js\" --compilers js:@babel/register --reporter spec"
   },
   "author": "Rich Gorman",
   "license": "MIT",
-  "dependencies": {
-    "babel-cli": "^6.26.0",
-    "babel-core": "^6.26.0"
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
+    "@babel/cli": "^7.2.3",
+    "@babel/core": "^7.2.2",
+    "@babel/plugin-transform-arrow-functions": "^7.2.0",
+    "@babel/plugin-transform-react-jsx": "^7.3.0",
+    "@babel/preset-env": "^7.3.1",
+    "@babel/register": "^7.0.0",
+    "babel-core": "^6.26.3",
     "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
     "babel-plugin-transform-react-jsx": "^6.8.0",
-    "babel-preset-es2015": "^6.16.0",
+    "babel-preset-env": "^1.7.0",
     "chai": "^3.5.0",
     "mocha": "^3.1.2",
     "uglify-js": "^2.7.3"

--- a/tests/remove-data-test-id.spec.js
+++ b/tests/remove-data-test-id.spec.js
@@ -1,4 +1,5 @@
-import { transform } from 'babel-core';
+import * as babel6 from 'babel-core';
+import * as babel7 from '@babel/core';
 import { expect } from 'chai';
 import { minify } from 'uglify-js';
 
@@ -7,128 +8,170 @@ const uglify = code => minify(code, {
   mangle: false
 }).code;
 
-const config = {
-  plugins: [
-    './src',
-    ['transform-react-jsx', { pragma: 'j' }],
-    ['transform-es2015-arrow-functions', {}]
-  ]
-};
+const runTests = (label, transform) => {
+  describe(label, () => {
+    describe('jsx-remove-data-test-id', () => {
+      it('does not replace data-something-else', () => {
+        const code = '<p data-something-else="cake-day">hi, finally it is cake time</p>';
+        const actual = transform(code, { usePlugin: true });
+        const expected = transform(code);
+        expect(uglify(actual)).to.equal(uglify(expected));
+      });
 
-const configWithoutPlugin = {
-  plugins: [
-    ['transform-react-jsx', { pragma: 'j' }],
-    ['transform-es2015-arrow-functions', {}]
-  ]
-};
+      it('does not remove attributes that contain "data-test-id" in part only', () => {
+        const code = '<p data-test-id-not="not-test-id">hi, finally it is cake time</p>';
+        const actual = transform(code, { usePlugin: true });
+        const expected = transform(code);
+        expect(uglify(actual)).to.equal(uglify(expected));
+      });
 
-describe('jsx-remove-data-test-id', () => {
-  it('does not replace data-something-else', () => {
-    const code = '<p data-something-else="cake-day">hi, finally it is cake time</p>';
-    const actual = transform(code, config).code;
-    const expected = transform(code, configWithoutPlugin).code;
-    expect(uglify(actual)).to.equal(uglify(expected));
-  });
+      it('removes data-test-id', () => {
+        const code = '<p data-test-id="test-id"></p>';
+        const expectedCode = '<p></p>';
+        const actual = transform(code, { usePlugin: true });
+        const expected = transform(expectedCode);
+        expect(uglify(actual)).to.equal(uglify(expected));
+      });
 
-  it('does not remove attributes that contain "data-test-id" in part only', () => {
-    const code = '<p data-test-id-not="not-test-id">hi, finally it is cake time</p>';
-    const actual = transform(code, config).code;
-    const expected = transform(code, configWithoutPlugin).code;
-    expect(uglify(actual)).to.equal(uglify(expected));
-  });
+      it('removes data-test-id funcs', () => {
+        const code = '<p data-test-id={() => {}}></p>';
+        const expectedCode = '<p></p>';
+        const actual = transform(code, { usePlugin: true });
+        const expected = transform(expectedCode);
+        expect(uglify(actual)).to.equal(uglify(expected));
+      });
 
-  it('removes data-test-id', () => {
-    const code = '<p data-test-id="test-id"></p>';
-    const expectedCode = '<p></p>';
-    const actual = transform(code, config).code;
-    const expected = transform(expectedCode, configWithoutPlugin).code;
-    expect(uglify(actual)).to.equal(uglify(expected));
-  });
+      it('removes data-test-id bools', () => {
+        const code = '<p data-test-id={false}></p>';
+        const expectedCode = '<p></p>';
+        const actual = transform(code, { usePlugin: true });
+        const expected = transform(expectedCode);
+        expect(uglify(actual)).to.equal(uglify(expected));
+      });
 
-  it('removes data-test-id funcs', () => {
-    const code = '<p data-test-id={() => {}}></p>';
-    const expectedCode = '<p></p>';
-    const actual = transform(code, config).code;
-    const expected = transform(expectedCode, configWithoutPlugin).code;
-    expect(uglify(actual)).to.equal(uglify(expected));
-  });
+      describe('with invalid options.attributes', () => {
+        it('throws error when attributes is empty string', () => {
+          const code = '<p selenium-id={false}></p>';
+          const expectedCode = '<p></p>';
+          const action = () => transform(code, {
+            useErroneousAttributes: true,
+            attributes: ''
+          });
+          expect(action).to.throw();
+        });
 
-  it('removes data-test-id bools', () => {
-    const code = '<p data-test-id={false}></p>';
-    const expectedCode = '<p></p>';
-    const actual = transform(code, config).code;
-    const expected = transform(expectedCode, configWithoutPlugin).code;
-    expect(uglify(actual)).to.equal(uglify(expected));
-  });
+        it('throws error when attributes is empty array', () => {
+          const code = '<p selenium-id={false}></p>';
+          const expectedCode = '<p></p>';
+          const action = () => transform(code, {
+            useErroneousAttributes: true,
+            attributes: []
+          });
+          expect(action).to.throw();
+        });
+      })
 
-  describe('with invalid options.attributes', () => {
-    it('throws error when attributes is empty string', () => {
-      const configWithErroneousAttributesOption = {
-        plugins: [
-          ['./src', {attributes: ''}],
-          ['transform-react-jsx', { pragma: 'j' }],
-          ['transform-es2015-arrow-functions', {}]
-        ]
-      };
-      const code = '<p selenium-id={false}></p>';
-      const expectedCode = '<p></p>';
-      const action = () => transform(code, configWithErroneousAttributesOption);
-      expect(action).to.throw();
-    });
+      describe('with valid options.attributes', () => {
+        it('does not remove attributes that match options.attributes in part only', () => {
+          const code = '<p selenium-id-not="not-test-id" no-useless-attr="useless">hi, finally it is cake time</p>';
+          const actual = transform(code, { useValidAttributes: true });
+          const expected = transform(code);
+          expect(uglify(actual)).to.equal(uglify(expected));
+        });
 
-    it('throws error when attributes is empty array', () => {
-      const configWithErroneousAttributesOption = {
-        plugins: [
-          ['./src', {attributes: []}],
-          ['transform-react-jsx', { pragma: 'j' }],
-          ['transform-es2015-arrow-functions', {}]
-        ]
-      };
-      const code = '<p selenium-id={false}></p>';
-      const expectedCode = '<p></p>';
-      const action = () => transform(code, configWithErroneousAttributesOption);
-      expect(action).to.throw();
+        it('removes options.attributes', () => {
+          const code = '<p selenium-id="test-id" useless-attr="useless"></p>';
+          const expectedCode = '<p></p>';
+          const actual = transform(code, { useValidAttributes: true });
+          const expected = transform(expectedCode);
+          expect(uglify(actual)).to.equal(uglify(expected));
+        });
+
+        it('removes options.attributes funcs', () => {
+          const code = '<p selenium-id={() => {}} useless-attr={() => {}}></p>';
+          const expectedCode = '<p></p>';
+          const actual = transform(code, { useValidAttributes: true });
+          const expected = transform(expectedCode);
+          expect(uglify(actual)).to.equal(uglify(expected));
+        });
+
+        it('removes options.attributes bools', () => {
+          const code = '<p selenium-id={false} useless-attr={true}></p>';
+          const expectedCode = '<p></p>';
+          const actual = transform(code, { useValidAttributes: true });
+          const expected = transform(expectedCode);
+          expect(uglify(actual)).to.equal(uglify(expected));
+        });
+      })
     });
   })
+}
 
-  describe('with valid options.attributes', () => {
-    const configWithValidAttributesOption = {
-      plugins: [
-        ['./src', { attributes: [ 'selenium-id', 'useless-attr' ] }],
-        ['transform-react-jsx', { pragma: 'j' }],
-        ['transform-es2015-arrow-functions', {}]
+runTests(
+  "babel6",
+  (
+    code,
+    {
+      useErroneousAttributes = false,
+      useValidAttributes = false,
+      usePlugin = false,
+      attributes
+    } = {}
+  ) => {
+    let plugins;
+    if (useErroneousAttributes) {
+      plugins = [
+        ["./src", { attributes }],
+        ["transform-react-jsx", { pragma: "j" }],
+        ["transform-es2015-arrow-functions", {}]
+      ];
+    } else if (useValidAttributes) {
+      plugins = [
+        ["./src", { attributes: ["selenium-id", "useless-attr"] }],
+        ["transform-react-jsx", { pragma: "j" }],
+        ["transform-es2015-arrow-functions", {}]
+      ];
+    } else {
+      plugins = [
+        usePlugin && "./src",
+        ["transform-react-jsx", { pragma: "j" }],
+        ["transform-es2015-arrow-functions", {}]
+      ].filter(Boolean);
+    }
+    return babel6.transform(code, { plugins }).code;
+  }
+);
+runTests(
+  "babel7",
+  (
+    code,
+    {
+      useErroneousAttributes = false,
+      useValidAttributes = false,
+      usePlugin = false,
+      attributes
+    } = {}
+  ) => {
+    let plugins
+    if (useErroneousAttributes) {
+      plugins = [
+        ['./src', { attributes }],
+        ["@babel/transform-react-jsx", { pragma: "j" }],
+        ["@babel/transform-arrow-functions", {}]
       ]
-    };
-
-    it('does not remove attributes that match options.attributes in part only', () => {
-      const code = '<p selenium-id-not="not-test-id" no-useless-attr="useless">hi, finally it is cake time</p>';
-      const actual = transform(code, configWithValidAttributesOption).code;
-      const expected = transform(code, configWithoutPlugin).code;
-      expect(uglify(actual)).to.equal(uglify(expected));
-    });
-
-    it('removes options.attributes', () => {
-      const code = '<p selenium-id="test-id" useless-attr="useless"></p>';
-      const expectedCode = '<p></p>';
-      const actual = transform(code, configWithValidAttributesOption).code;
-      const expected = transform(expectedCode, configWithoutPlugin).code;
-      expect(uglify(actual)).to.equal(uglify(expected));
-    });
-
-    it('removes options.attributes funcs', () => {
-      const code = '<p selenium-id={() => {}} useless-attr={() => {}}></p>';
-      const expectedCode = '<p></p>';
-      const actual = transform(code, configWithValidAttributesOption).code;
-      const expected = transform(expectedCode, configWithoutPlugin).code;
-      expect(uglify(actual)).to.equal(uglify(expected));
-    });
-
-    it('removes options.attributes bools', () => {
-      const code = '<p selenium-id={false} useless-attr={true}></p>';
-      const expectedCode = '<p></p>';
-      const actual = transform(code, configWithValidAttributesOption).code;
-      const expected = transform(expectedCode, configWithoutPlugin).code;
-      expect(uglify(actual)).to.equal(uglify(expected));
-    });
-  })
-});
+    } else if (useValidAttributes) {
+      plugins = [
+        ['./src', { attributes: ['selenium-id', 'useless-attr'] }],
+        ["@babel/transform-react-jsx", { pragma: "j" }],
+        ["@babel/transform-arrow-functions", {}]
+      ]
+    } else {
+      plugins = [
+        usePlugin && "./src",
+        ["@babel/transform-react-jsx", { pragma: "j" }],
+        ["@babel/transform-arrow-functions", {}]
+      ].filter(Boolean)
+    }
+    return babel7.transformSync(code, { plugins }).code;
+  }
+);


### PR DESCRIPTION
It's a breaking change of course, but one worth doing.

I've made sure that this still works with babel@6, if one would want remove peer dep warning they can install `@babel/core@6.0.0-bridge.1`