### PR TITLE
Remove data-test-id from objects

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,18 @@ const getAttributeIdentifiers = options => {
 
 const RemoveDataTestIds = ({ types: t }) => {
   const visitor = {
+    ObjectProperty: (path, state) => {
+      const attributeIdentifiers = getAttributeIdentifiers(state.opts);
+  
+      const isTestIdProperty = (key) => {
+        return attributeIdentifiers.find((attribute) => {
+          return t.isStringLiteral(key, { value: attribute })
+        });
+      };
+  
+      if (isTestIdProperty(path.node.key))
+        path.remove();
+    },
     JSXOpeningElement: (path, state) => {
       if (path.node.hasStripped) {
         return;

--- a/tests/remove-data-test-id.spec.js
+++ b/tests/remove-data-test-id.spec.js
@@ -49,6 +49,38 @@ const runTests = (label, transform) => {
         expect(uglify(actual)).to.equal(uglify(expected));
       });
 
+      it('removes data-test-id properties from objects and their nested objects', () => {
+        const code = '<p object={{"data-test-id": "test-id", something: "else"}}></p>';
+        const expectedCode = '<p object={{something: "else"}}></p>';
+        const actual = transform(code, { usePlugin: true });
+        const expected = transform(expectedCode);
+        expect(uglify(actual)).to.equal(uglify(expected));
+      })
+      
+      it('removes data-test-id properties from nested objects', () => {
+        const code = '<p object={{nested: {"data-test-id": "test-id"}}}></p>';
+        const expectedCode = '<p object={{nested:{}}}></p>';
+        const actual = transform(code, { usePlugin: true });
+        const expected = transform(expectedCode);
+        expect(uglify(actual)).to.equal(uglify(expected));
+      })
+
+      it('does not remove empty object expressions and their relative JSX attributes', () => {
+        const code = '<p object={{"data-test-id": "test-id"}}></p>';
+        const expectedCode = '<p object={{}}></p>';
+        const actual = transform(code, { usePlugin: true });
+        const expected = transform(expectedCode);
+        expect(uglify(actual)).to.equal(uglify(expected));
+      })
+      
+      it('does not remove properties that contain "data-test-id" in part only', () => {
+        const code = '<p object={{"data-test-id-not": "test-id", nestedObj: {"data-test-id-not": "test-id"}}}></p>';
+        const expectedCode = '<p object={{"data-test-id-not": "test-id", nestedObj:{"data-test-id-not": "test-id"}}}></p>';
+        const actual = transform(code, { usePlugin: true });
+        const expected = transform(expectedCode);
+        expect(uglify(actual)).to.equal(uglify(expected));
+      })
+      
       describe('with invalid options.attributes', () => {
         it('throws error when attributes is empty string', () => {
           const code = '<p selenium-id={false}></p>';


### PR DESCRIPTION
This PR fix #39 

This probably isn't the best solution because it checks all properties in all objects in the parsed code, even those that aren't in the JSX tags, but I've tested it in some big projects and there are not side effect.  
The only case this could lead to issues is if there are direct calls to the "data-test-id" object in the code (except for tests). This is quite  unlikely but not obvious. It should be added to docs.  

But I'm dumb about AST so I can't do better 🙄

